### PR TITLE
fix DESCRIPTION fmt, utils::

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,10 @@ Type: Package
 Title: Exact (Restricted) Likelihood Ratio Tests for Mixed and Additive Models
 Version: 3.1-6
 Date: 2019-11-19
-Authors@R: c(person("Fabian", "Scheipl", role = c("aut", "cre"), email = "fabian.scheipl@stat.uni-muenchen.de"), person("Ben", "Bolker", role = "ctb",
-comment=c(ORCID="0000-0002-2127-0443")))
+Authors@R: c(person("Fabian", "Scheipl", role = c("aut", "cre"),
+	   email = "fabian.scheipl@stat.uni-muenchen.de"),
+	   person("Ben", "Bolker", role = "ctb",
+	   comment=c(ORCID="0000-0002-2127-0443")))
 Maintainer: Fabian Scheipl <fabian.scheipl@stat.uni-muenchen.de>
 Description: Rapid, simulation-based exact (restricted) likelihood ratio tests
     for testing the presence of variance components/nonparametric terms for

--- a/R/exactRLRT.R
+++ b/R/exactRLRT.R
@@ -166,7 +166,7 @@
         }
       }     
     }
-    lmer_nm <- if (packageVersion("lme4")<="1.1.21") "Df" else "npar"
+    lmer_nm <- if (utils::packageVersion("lme4")<="1.1.21") "Df" else "npar"
     ## bug fix submitted by Andrzej Galecki 3/10/2009
     DFx <- switch(c.m, lme = anova(mA,m0)$df, 
                   lmerMod = anova(mA, m0, refit = FALSE)[[lmer_nm]]) 


### PR DESCRIPTION
this fixes a mistake I made in the DESCRIPTION file (which was breaking your Travis checks) and uses `utils::` to avoid a NOTE about importing `packageVersion` (also my fault).

Would you be willing to submit a new version of this to CRAN in the near future? I need to submit a new lme4 version, and CRAN doesn't like it when reverse dependencies break.

I didn't update the NEWS file (maybe not necessary; no changes to API) or bump the version in the DESCRIPTION (not necessary either as version on CRAN is only 3.1-3 and the GH version is 3.1-6)
